### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - uses: actions/checkout@v4
       - run: pip install -q uv && uv pip install --system ruff==0.4.3 isort
       - run: ruff format --check --diff .

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest]
       fail-fast: false
     steps:
@@ -75,15 +75,15 @@ jobs:
           pushd ..
           python -m pytest --import-mode=append -svx $REPONAME/nle/tests
           popd
-  test_sdist_3_12:
-    name: Test sdist on MacOS w/ Py3.12
+  test_sdist_3_13:
+    name: Test sdist on MacOS w/ Py3.13
     needs: test_repo
     runs-on: macos-latest
     steps:
-      - name: Setup Python 3.12 env
+      - name: Setup Python 3.13 env
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Ensure latest pip, wheel & setuptools
         run: python -m pip install -q --upgrade pip wheel setuptools
       - name: Install dependencies
@@ -127,7 +127,7 @@ jobs:
         if: github.event_name != 'release'
         uses: pypa/cibuildwheel@v2.19.2 # The main configuration is in pyproject.toml
         env:
-          CIBW_BUILD: "cp312-manylinux*" # Build only python 3.12 wheels for testing
+          CIBW_BUILD: "cp313-manylinux*" # Build only python 3.13 wheels for testing
           # Increase verbosity to see what's going on in the build in case of failure
           CIBW_BUILD_VERBOSITY: 3
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
@@ -143,15 +143,15 @@ jobs:
         with:
           name: python-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
-  test_manylinux_3_12:
-    name: Test manylinux wheel on Ubuntu w/ Py3.12
+  test_manylinux_3_13:
+    name: Test manylinux wheel on Ubuntu w/ Py3.13
     needs: build_wheels
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python 3.12 env
+      - name: Setup Python 3.13 env
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
       - name: Ensure latest pip, wheel & setuptools
         run: python -m pip install -q --upgrade pip wheel tools
       - uses: actions/checkout@v4
@@ -164,7 +164,7 @@ jobs:
           path: dist
       - name: Install from wheel # Install wheel mathcing the Python version and architecture
         run: | 
-          WHEELNAME=$(ls dist/*312*manylinux*x86_64*.whl) 
+          WHEELNAME=$(ls dist/*313*manylinux*x86_64*.whl) 
           MODE="[all]"
           pip install "$WHEELNAME$MODE"
       - name: Run tests outside repo dir
@@ -177,7 +177,7 @@ jobs:
   # Use prereleases to test publish the artefacts to testpypi
   test_deploy:
     name: Deploy artefacts to testpypi
-    needs: [test_sdist_3_12, test_manylinux_3_12]
+    needs: [test_sdist_3_13, test_manylinux_3_13]
     if: github.event_name == 'release' && github.event.action == 'prereleased'
     runs-on: ubuntu-latest
     environment:
@@ -223,7 +223,7 @@ jobs:
   #      functionalities like workflow dependencies :|
   deploy_sdist:
     name: Deploy sdist to pypi
-    needs: [test_sdist_3_12, test_manylinux_3_12]  
+    needs: [test_sdist_3_13, test_manylinux_3_13]  
     if: github.event_name == 'release' && github.event.action == 'released'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -125,7 +125,7 @@ jobs:
           submodules: recursive
       - name: Build wheels
         if: github.event_name != 'release'
-        uses: pypa/cibuildwheel@v2.19.2 # The main configuration is in pyproject.toml
+        uses: pypa/cibuildwheel@v3.1.3 # The main configuration is in pyproject.toml
         env:
           CIBW_BUILD: "cp313-manylinux*" # Build only python 3.13 wheels for testing
           # Increase verbosity to see what's going on in the build in case of failure
@@ -134,7 +134,7 @@ jobs:
             auditwheel show {wheel} && auditwheel repair -w {dest_dir} {wheel}
       - name: Build release wheels
         if: github.event_name == 'release' && (github.event.action == 'released' || github.event.action == 'prereleased')
-        uses: pypa/cibuildwheel@v2.19.2 # The main configuration is in pyproject.toml
+        uses: pypa/cibuildwheel@v3.1.3 # The main configuration is in pyproject.toml
         env:
           # Set NLE_RELEASE_BUILD to 1 to build release wheels
           CIBW_ENVIRONMENT: "NLE_RELEASE_BUILD=1"

--- a/doc/nle/ARCHITECTURE.md
+++ b/doc/nle/ARCHITECTURE.md
@@ -147,7 +147,7 @@ nethack, instead of `nle.h`, and in fact we can test this with the file
 
 ### Layer 4: Binding to Python: Exposing the Game
 
-- **libraries:** `_pynethack.cpython-37.*`
+- **libraries:** `_pynethack.cpython-3xx.*`
 - **key directories & files:**[`pynethack.cc`](https://github.com/NetHack-LE/nle/blob/main/win/rl/pynethack.cc),
 [`src/monst.c`](https://github.com/NetHack-LE/nle/blob/main/src/monst.c),
 [`src/objects.c`](https://github.com/NetHack-LE/nle/blob/main/src/objects.c),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,11 @@ allow-dict-calls-with-keyword-arguments = true
 
 [tool.cibuildwheel]
 # We need to build wheels for the following Python versions:
-build = "cp{38,39,310,311,312}-*"
+build = "cp{39,310,311,312,313}-*"
 
 [tool.cibuildwheel.linux]
 # Only manylinux is supported (no musllinux)
-build = "cp{38,39,310,311,312}-manylinux*"
+build = "cp{39,310,311,312,313}-manylinux*"
 
 # We need to clean up the build directory, all .so files, and CMakeCache.txt
 # and install the dependencies using yum, as manylinux2014 image is CentOS 7-based

--- a/setup.py
+++ b/setup.py
@@ -168,6 +168,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Programming Language :: C",
             "Programming Language :: C++",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",

--- a/third_party/converter/stripgfx.c
+++ b/third_party/converter/stripgfx.c
@@ -344,7 +344,7 @@ static unsigned char dec_graphics[MAXPCHARS] = {
 
 /* clang-format on */
 
-void populate_gfx_arrays() {
+void populate_gfx_arrays(void) {
   int i;
 
 

--- a/third_party/converter/stripgfx.h
+++ b/third_party/converter/stripgfx.h
@@ -1,7 +1,7 @@
 #ifndef INCLUDED_stripgfx_h
 #define INCLUDED_stripgfx_h
 
-void populate_gfx_arrays();
+void populate_gfx_arrays(void);
 unsigned char strip_gfx(unsigned char inchar, int use_dec);
 
 #endif /* !INCLUDED_stripgfx_h */


### PR DESCRIPTION
Maintenance in preparation for Gymnasium upgrade:
- Add Python 3.13 to build
- Fix strict prototype error in converter 